### PR TITLE
Improve F3 title scrolling

### DIFF
--- a/modules/editor.py
+++ b/modules/editor.py
@@ -561,6 +561,12 @@ class Editor(QPlainTextEdit):
                 cursor.movePosition(QTextCursor.StartOfBlock)
                 self.setTextCursor(cursor)
                 self.ensureCursorVisible()
+                # Scroll so the found Title line is positioned at the top of the
+                # visible editor area
+                cursor_rect = self.cursorRect(cursor)
+                sb = self.verticalScrollBar()
+                new_val = sb.value() + cursor_rect.top()
+                sb.setValue(max(0, min(new_val, sb.maximum())))
                 return True
 
     def _send_to_vhd(self, target_file):


### PR DESCRIPTION
## Summary
- ensure the next `Title:` line scrolls to the top when using F3

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_b_684a8b55c36c832a93bc7417d76714f3